### PR TITLE
ci: test against Terraform 0.15.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        terraform-versions: [0.14.8]
+        terraform-versions: [0.14.x, 0.15.x]
         go-versions: [1.16.x]
     steps:
       - name: Checkout


### PR DESCRIPTION
Test against the latest Terraform 0.14.x and 0.15.x versions.